### PR TITLE
Revised spatial_availability to group by destination

### DIFF
--- a/R/spatial_availability.R
+++ b/R/spatial_availability.R
@@ -100,7 +100,7 @@ spatial_availability <- function(travel_matrix,
   data[
     ,
     impedance_bal_fac := opp_weight / sum(opp_weight),
-    by = c("from_id", group_by)
+    by = c("to_id", group_by)
   ]
 
   data[

--- a/tests/testthat/test-spatial_availability.R
+++ b/tests/testthat/test-spatial_availability.R
@@ -171,7 +171,7 @@ test_that("fill_missing_ids arg works correctly", {
     data.table::data.table(
       id = rep(c("89a88cdb57bffff", "89a88cdb597ffff"), each = 2),
       mode = rep(c("transit", "transit2"), times = 2),
-      jobs = c(337410L, 0L, 158642L, 496053L)
+      jobs = c(271899L, 0L, 224153L, 496053L)
     )
   )
 
@@ -182,7 +182,7 @@ test_that("fill_missing_ids arg works correctly", {
     data.table::data.table(
       id = c("89a88cdb57bffff", "89a88cdb597ffff", "89a88cdb597ffff"),
       mode = c("transit", "transit", "transit2"),
-      jobs = c(337410L, 158642L, 496053L)
+      jobs = c(271899L, 224153L, 496053L)
     )
   )
 })
@@ -273,7 +273,7 @@ test_that("calculates spatial availability correctly", {
     result,
     data.table::data.table(
       id = c("A", "B", "C"),
-      jobs = c(66831, 133197, 9971)
+      jobs = c(66833, 133203, 9963)
     )
   )
 })


### PR DESCRIPTION
Changing the grouping of the summation when calculating the impedance balance factor brings it in line with the formulas in Soukhov et al. (2023). The rationale for grouping by destination (i.e., `by = c("to_id", group_by)`) is that destinations draw preferentially from closer origins. Grouping by origin (i.e., `by = c("from_id", group_by)`) is not necessarily wrong - I think it means that origins send preferentially to closer centers. This will generally give different results, since the process is different! Soukhov et al. (2023) do not discuss this (actually, we did not see this possibility), but it does open intriguing possibilities for representing a variety of process (attraction-driven, propulsion-driven, potentially doubly constrained?). We need to think more about this, but for the time being, the change in this commit ensures that the function works exactly as explained in Soukhov et al. (2023)