### PR TITLE
Update spatial_availability.R

### DIFF
--- a/R/spatial_availability.R
+++ b/R/spatial_availability.R
@@ -112,11 +112,17 @@ spatial_availability <- function(travel_matrix,
     impedance_bal_fac := opp_weight / sum(opp_weight),
     by = c("to_id", group_by)
   ]
-
+  
+  data[
+    ,
+    total_pa := sum(demand_bal_fac * impedance_bal_fac),
+    by = c("to_id", group_by)
+  ]
+  
   data[
     ,
     combined_bal_fac := demand_bal_fac * impedance_bal_fac /
-      sum(demand_bal_fac * impedance_bal_fac),
+      total_pa,
     by = c("to_id", group_by)
   ]
 


### PR DESCRIPTION
I believe one summation is missing. The denominator of the combined_bal_fac is the result of a summation of the demand_bal_fac * impedance_bal_fac by "to_id". See equation (9) https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0278468

This updated function now yields the exact result as the synthetic example in Soukhov et al. (2023) (last row of Table 1). 